### PR TITLE
refactor(MultiTape): split into Copy.lean and Eq.lean

### DIFF
--- a/Cslib.lean
+++ b/Cslib.lean
@@ -49,13 +49,15 @@ public import Cslib.Computability.Machines.MultiTapeTuring.PopRoutine
 public import Cslib.Computability.Machines.MultiTapeTuring.PushRoutine
 public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Boolean
 public import Cslib.Computability.Machines.MultiTapeTuring.Routines.CaseDispatch
+public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Copy
+public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Eq
 public import Cslib.Computability.Machines.MultiTapeTuring.Routines.ListIteration
 public import Cslib.Computability.Machines.MultiTapeTuring.Routines.ListOps
-public import Cslib.Computability.Machines.MultiTapeTuring.Routines.MultiTape
 public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Navigation
 public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Put
 public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Skip
 public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Typed
+public import Cslib.Computability.Machines.MultiTapeTuring.Routines.While
 public import Cslib.Computability.Machines.MultiTapeTuring.Satisfiability
 public import Cslib.Computability.Machines.MultiTapeTuring.SequentialCombinator
 public import Cslib.Computability.Machines.MultiTapeTuring.StructuralMachines

--- a/Cslib/Computability/Machines/MultiTapeTuring/Routines/Copy.lean
+++ b/Cslib/Computability/Machines/MultiTapeTuring/Routines/Copy.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2026 Christian Reitwiessner. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Reitwiessner
+-/
+
+module
+
+public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Put
+public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Typed
+
+namespace Turing
+namespace Routines
+
+/-- Copy a Data-encoded value from tape `i` to tape `j`
+    (prepending the encoding to tape `j`). -/
+public def copyEnc {k : ℕ} (i j : Fin k) (h_eq : i ≠ j) : MultiTapeTM k Char := sorry
+
+/-- `copyEnc i j` copies the `Data` element at the current path position
+    of tape `i` and writes it to tape `j` (overwrites everything).
+    Tape `i` is not modified. -/
+@[simp]
+public lemma copyEnc_eval_struct {k : ℕ} {i j : Fin k}
+    {views : Fin k → TapeView}
+    {h_ne : i ≠ j} :
+    (copyEnc i j h_ne).eval_struct views = some (Function.update views j
+      (.ofData (views i).current)) := by sorry
+
+end Routines
+end Turing

--- a/Cslib/Computability/Machines/MultiTapeTuring/Routines/Eq.lean
+++ b/Cslib/Computability/Machines/MultiTapeTuring/Routines/Eq.lean
@@ -12,14 +12,6 @@ public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Typed
 namespace Turing
 namespace Routines
 
--- ═══════════════════════════════════════════════════════════════════════════
--- Copy and comparison
--- ═══════════════════════════════════════════════════════════════════════════
-
-/-- Copy a Data-encoded value from tape `i` to tape `j`
-    (prepending the encoding to tape `j`). -/
-public def copyEnc {k : ℕ} (i j : Fin k) (h_eq : i ≠ j) : MultiTapeTM k Char := sorry
-
 /-- Compare Data-encoded values on tapes `i` and `j`.
     Runs `tm_eq` if values are equal, `tm_neq` if not.
     Tapes `i` and `j` are restored to their original positions. -/
@@ -40,16 +32,6 @@ public lemma isEq.computes_fun {k : ℕ} (i j result : Fin k)
       (isEq i j result)
       (fun (d₁ : α) (d₂ : α) => d₂ == d₁) i j result := by
   sorry
-
-/-- `copyEnc i j` copies the `Data` element at the current path position
-    of tape `i` and writes it to tape `j` (overwrites everything).
-    Tape `i` is not modified. -/
-@[simp]
-public lemma copyEnc_eval_struct {k : ℕ} {i j : Fin k}
-    {views : Fin k → TapeView}
-    {h_ne : i ≠ j} :
-    (copyEnc i j h_ne).eval_struct views = some (Function.update views j
-      (.ofData (views i).current)) := by sorry
 
 /-- `isEq i j result` compares the `Data` elements at the current positions
     of tapes `i` and `j`, and writes the boolean result to tape `result`

--- a/Cslib/Computability/Machines/MultiTapeTuring/Routines/ListIteration.lean
+++ b/Cslib/Computability/Machines/MultiTapeTuring/Routines/ListIteration.lean
@@ -8,7 +8,7 @@ module
 
 public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Boolean
 public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Skip
-public import Cslib.Computability.Machines.MultiTapeTuring.Routines.MultiTape
+public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Eq
 public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Navigation
 
 set_option autoImplicit false

--- a/Cslib/Computability/Machines/MultiTapeTuring/Routines/While.lean
+++ b/Cslib/Computability/Machines/MultiTapeTuring/Routines/While.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 Christian Reitwiessner. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Reitwiessner
+-/
+
+module
+
+public import Cslib.Computability.Machines.MultiTapeTuring.StructuralMachines
+public import Cslib.Computability.Machines.MultiTapeTuring.TapeView
+
+namespace Turing
+namespace Routines
+
+/-- Repeatedly run a sub routine as long as the current item on tape `i` is equal to a given
+encoding.
+-/
+public def doWhileEq {k : ℕ} (d : Data) (i : Fin k) (tm : MultiTapeTM k Char) :
+    MultiTapeTM k Char := sorry
+
+-- TODO
+-- public theorem doWhileEq.eval_struct {k : ℕ} {d : Data} {i : Fin k} {tm : MultiTapeTM k Char}
+--   {h_halts : ∀ views, tm.HaltsOn (TapeView.toBiTape ∘ views)}
+--   {views : Fin k → TapeView}
+--   (n : ℕ)
+--   (h_exists : ((tm.eval_struct · sorry)^[n] views i).current = d)
+--   (h_min : ∀ n' < n, ((tm.eval_struct sorry)^[n'] views i).current ≠ d) :
+--     (doWhileEq d i tm).eval_struct views = .some ((tm.eval_struct sorry)^[n] views) := by
+--   sorry
+
+
+end Routines
+end Turing

--- a/Cslib/Computability/Machines/MultiTapeTuring/Satisfiability.lean
+++ b/Cslib/Computability/Machines/MultiTapeTuring/Satisfiability.lean
@@ -10,7 +10,7 @@ public import Cslib.Computability.Machines.MultiTapeTuring.Basic
 public import Cslib.Computability.Machines.MultiTapeTuring.TapeView
 public import Cslib.Computability.Machines.MultiTapeTuring.StructuralMachines
 public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Navigation
-public import Cslib.Computability.Machines.MultiTapeTuring.Routines.MultiTape
+public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Copy
 public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Put
 public import Cslib.Computability.Machines.MultiTapeTuring.Routines.ListIteration
 public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Typed

--- a/Cslib/Computability/Machines/MultiTapeTuring/UniversalTM.lean
+++ b/Cslib/Computability/Machines/MultiTapeTuring/UniversalTM.lean
@@ -10,7 +10,8 @@ public import Cslib.Computability.Machines.MultiTapeTuring.Basic
 public import Cslib.Computability.Machines.MultiTapeTuring.TapeView
 public import Cslib.Computability.Machines.MultiTapeTuring.StructuralMachines
 public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Navigation
-public import Cslib.Computability.Machines.MultiTapeTuring.Routines.MultiTape
+public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Copy
+public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Eq
 public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Put
 public import Cslib.Computability.Machines.MultiTapeTuring.Routines.ListIteration
 public import Cslib.Computability.Machines.MultiTapeTuring.Routines.Typed


### PR DESCRIPTION
Split MultiTape.lean into two focused files:
- Copy.lean: copyEnc definition and eval_struct lemma
- Eq.lean: eqEnc, isEq definitions and lemmas

Updated imports in Satisfiability.lean, UniversalTM.lean, and ListIteration.lean accordingly.